### PR TITLE
Update requirements.txt to temporarily fix openai

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openai
+openai==0.27.8
 transformers==4.24.0
 tree_sitter
 sqlparse


### PR DESCRIPTION
For modern "openai" packages, there will be an error if you directly write code like this: openai.api_requestor.TIMEOUT_SECS = 60

I got the following error:
api_utils.py", line 47, in config_args_and_api
    openai.api_requestor.TIMEOUT_SECS = 60
AttributeError: module 'openai' has no attribute 'api_requestor'



Although we should fix the code to make it more formal. A temporary fix/hack is to use an old version of the "openai" package ,which was available before the previous commit of the paper,